### PR TITLE
feat:Add stream-description field to openapi.yaml for API documentation

### DIFF
--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -1512,6 +1512,7 @@ paths:
         - public
       x-fern-streaming:
         stream-condition: $request.stream
+        stream-description: "<Warning>\nThis API is marked as \"Legacy\" and is no longer maintained. Follow the [migration guide](https://docs.cohere.com/docs/migrating-from-cogenerate-to-cochat) to start using the Chat with Streaming API.\n</Warning>\nGenerates realistic text conditioned on a given input.\n"
         response:
           type: object
           x-fern-type-name: Generation


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a warning note in the API specification indicating the legacy status of a streaming endpoint
	- Included a migration guide link for users to transition to the current Chat with Streaming API
<!-- end of auto-generated comment: release notes by coderabbit.ai -->