### PR TITLE
feat:Add supports_vision boolean property to OpenAPI components

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.Models.GetModelResponse.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.GetModelResponse.g.cs
@@ -39,6 +39,12 @@ namespace Cohere
         public string? TokenizerUrl { get; set; }
 
         /// <summary>
+        /// Whether the model supports image inputs or not.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("supports_vision")]
+        public bool? SupportsVision { get; set; }
+
+        /// <summary>
         /// The API endpoints that the model is default to.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("default_endpoints")]
@@ -68,6 +74,9 @@ namespace Cohere
         /// <param name="tokenizerUrl">
         /// Public URL to the tokenizer's configuration file.
         /// </param>
+        /// <param name="supportsVision">
+        /// Whether the model supports image inputs or not.
+        /// </param>
         /// <param name="defaultEndpoints">
         /// The API endpoints that the model is default to.
         /// </param>
@@ -80,6 +89,7 @@ namespace Cohere
             bool? finetuned,
             double? contextLength,
             string? tokenizerUrl,
+            bool? supportsVision,
             global::System.Collections.Generic.IList<global::Cohere.CompatibleEndpoint>? defaultEndpoints)
         {
             this.Name = name;
@@ -87,6 +97,7 @@ namespace Cohere
             this.Finetuned = finetuned;
             this.ContextLength = contextLength;
             this.TokenizerUrl = tokenizerUrl;
+            this.SupportsVision = supportsVision;
             this.DefaultEndpoints = defaultEndpoints;
         }
 

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -16367,6 +16367,11 @@ components:
           description: Public URL to the tokenizer's configuration file.
           x-fern-audiences:
             - public
+        supports_vision:
+          type: boolean
+          description: Whether the model supports image inputs or not.
+          x-fern-audiences:
+            - public
         default_endpoints:
           type: array
           items:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an indicator for vision support, allowing users to easily determine if a model accepts image inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->