### PR TITLE
feat:Update OpenAPI citation param: command-r7b-12-2024 & command-a-03-2025

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.Models.CitationOptions.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.CitationOptions.g.cs
@@ -11,7 +11,7 @@ namespace Cohere
         /// <summary>
         /// Defaults to `"accurate"`.<br/>
         /// Dictates the approach taken to generating citations as part of the RAG flow by allowing the user to specify whether they want `"accurate"` results, `"fast"` results or no results.<br/>
-        /// **Note**: `command-r7b-12-2024` only supports `"fast"` and `"off"` modes. Its default is `"fast"`.
+        /// **Note**: `command-r7b-12-2024` and `command-a-03-2025` only support `"fast"` and `"off"` modes. The default is `"fast"`.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("mode")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Cohere.JsonConverters.CitationOptionsModeJsonConverter))]
@@ -29,7 +29,7 @@ namespace Cohere
         /// <param name="mode">
         /// Defaults to `"accurate"`.<br/>
         /// Dictates the approach taken to generating citations as part of the RAG flow by allowing the user to specify whether they want `"accurate"` results, `"fast"` results or no results.<br/>
-        /// **Note**: `command-r7b-12-2024` only supports `"fast"` and `"off"` modes. Its default is `"fast"`.
+        /// **Note**: `command-r7b-12-2024` and `command-a-03-2025` only support `"fast"` and `"off"` modes. The default is `"fast"`.
         /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]

--- a/src/libs/Cohere/Generated/Cohere.Models.CitationOptionsMode.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.CitationOptionsMode.g.cs
@@ -6,7 +6,7 @@ namespace Cohere
     /// <summary>
     /// Defaults to `"accurate"`.<br/>
     /// Dictates the approach taken to generating citations as part of the RAG flow by allowing the user to specify whether they want `"accurate"` results, `"fast"` results or no results.<br/>
-    /// **Note**: `command-r7b-12-2024` only supports `"fast"` and `"off"` modes. Its default is `"fast"`.
+    /// **Note**: `command-r7b-12-2024` and `command-a-03-2025` only support `"fast"` and `"off"` modes. The default is `"fast"`.
     /// </summary>
     public enum CitationOptionsMode
     {

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -12158,7 +12158,7 @@ components:
             - ACCURATE
             - OFF
           type: string
-          description: "Defaults to `\"accurate\"`.\nDictates the approach taken to generating citations as part of the RAG flow by allowing the user to specify whether they want `\"accurate\"` results, `\"fast\"` results or no results.\n\n**Note**: `command-r7b-12-2024` only supports `\"fast\"` and `\"off\"` modes. Its default is `\"fast\"`.\n"
+          description: "Defaults to `\"accurate\"`.\nDictates the approach taken to generating citations as part of the RAG flow by allowing the user to specify whether they want `\"accurate\"` results, `\"fast\"` results or no results.\n\n**Note**: `command-r7b-12-2024` and `command-a-03-2025` only support `\"fast\"` and `\"off\"` modes. The default is `\"fast\"`.\n"
       description: Options for controlling citation generation.
     CitationStartEvent:
       allOf:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Clarified the API parameter for citation generation to indicate that both supported models now offer "fast" and "off" modes, with "fast" set as the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->