### PR TITLE
feat:Remove texts from required fields in EmbedByTypeResponse schema

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.Models.EmbedByTypeResponse.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.EmbedByTypeResponse.g.cs
@@ -46,8 +46,7 @@ namespace Cohere
         /// The text entries for which embeddings were returned.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("texts")]
-        [global::System.Text.Json.Serialization.JsonRequired]
-        public required global::System.Collections.Generic.IList<string> Texts { get; set; }
+        public global::System.Collections.Generic.IList<string>? Texts { get; set; }
 
         /// <summary>
         /// Additional properties that are not explicitly defined in the schema
@@ -76,18 +75,18 @@ namespace Cohere
 #endif
         public EmbedByTypeResponse(
             string id,
-            global::System.Collections.Generic.IList<string> texts,
             global::System.Collections.Generic.IList<global::Cohere.Image>? images,
             global::Cohere.ApiMeta? meta,
             global::Cohere.EmbedByTypeResponseResponseType? responseType,
+            global::System.Collections.Generic.IList<string>? texts,
             global::Cohere.EmbedByTypeResponseEmbeddings embeddings = default!)
         {
             this.Id = id ?? throw new global::System.ArgumentNullException(nameof(id));
-            this.Texts = texts ?? throw new global::System.ArgumentNullException(nameof(texts));
             this.Embeddings = embeddings;
             this.Images = images;
             this.Meta = meta;
             this.ResponseType = responseType;
+            this.Texts = texts;
         }
 
         /// <summary>

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -12863,7 +12863,6 @@ components:
       required:
         - id
         - embeddings
-        - texts
         - api_version
       type: object
       properties:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to indicate that the "texts" field is no longer required in embedding responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->