### PR TITLE
feat:Remove api_version field from EmbedByTypeResponse example in OpenAPI spec

### DIFF
--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -12989,7 +12989,6 @@ components:
       x-examples:
         Example:
           value:
-            api_version: v2
             embeddings:
               float:
                 - 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the example response in the API documentation by removing the `api_version: v2` field from the embedding response schema example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->