### PR TITLE
feat:Add is_deprecated boolean property to model schema in OpenAPI spec

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.Models.GetModelResponse.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.GetModelResponse.g.cs
@@ -39,6 +39,12 @@ namespace Cohere
         public bool? Finetuned { get; set; }
 
         /// <summary>
+        /// Whether the model is deprecated or not.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("is_deprecated")]
+        public bool? IsDeprecated { get; set; }
+
+        /// <summary>
         /// Specify this name in the `model` parameter of API requests to use your chosen model.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("name")]
@@ -80,6 +86,9 @@ namespace Cohere
         /// <param name="finetuned">
         /// Whether the model has been fine-tuned or not.
         /// </param>
+        /// <param name="isDeprecated">
+        /// Whether the model is deprecated or not.
+        /// </param>
         /// <param name="name">
         /// Specify this name in the `model` parameter of API requests to use your chosen model.
         /// </param>
@@ -98,6 +107,7 @@ namespace Cohere
             global::System.Collections.Generic.IList<global::Cohere.CompatibleEndpoint>? endpoints,
             global::System.Collections.Generic.IList<string>? features,
             bool? finetuned,
+            bool? isDeprecated,
             string? name,
             bool? supportsVision,
             string? tokenizerUrl)
@@ -107,6 +117,7 @@ namespace Cohere
             this.Endpoints = endpoints;
             this.Features = features;
             this.Finetuned = finetuned;
+            this.IsDeprecated = isDeprecated;
             this.Name = name;
             this.SupportsVision = supportsVision;
             this.TokenizerUrl = tokenizerUrl;

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -15956,6 +15956,11 @@ components:
           description: Whether the model has been fine-tuned or not.
           x-fern-audiences:
             - public
+        is_deprecated:
+          type: boolean
+          description: Whether the model is deprecated or not.
+          x-fern-audiences:
+            - public
         name:
           type: string
           description: Specify this name in the `model` parameter of API requests to use your chosen model.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new field to the model details response that indicates whether a model is deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->