### PR TITLE
feat:Update preset parameter description URL in /v1/classify OpenAPI spec

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.CohereClient.Classify.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.CohereClient.Classify.g.cs
@@ -645,7 +645,7 @@ namespace Cohere
         /// Included only in requests
         /// </param>
         /// <param name="preset">
-        /// The ID of a custom playground preset. You can create presets in the [playground](https://dashboard.cohere.com/playground/classify?model=large). If you use a preset, all other parameters become optional, and any included parameters will override the preset's parameters.<br/>
+        /// The ID of a custom playground preset. You can create presets in the [playground](https://dashboard.cohere.com/playground). If you use a preset, all other parameters become optional, and any included parameters will override the preset's parameters.<br/>
         /// Included only in requests<br/>
         /// Example: my-preset-a58sbd
         /// </param>

--- a/src/libs/Cohere/Generated/Cohere.ICohereClient.Classify.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.ICohereClient.Classify.g.cs
@@ -40,7 +40,7 @@ namespace Cohere
         /// Included only in requests
         /// </param>
         /// <param name="preset">
-        /// The ID of a custom playground preset. You can create presets in the [playground](https://dashboard.cohere.com/playground/classify?model=large). If you use a preset, all other parameters become optional, and any included parameters will override the preset's parameters.<br/>
+        /// The ID of a custom playground preset. You can create presets in the [playground](https://dashboard.cohere.com/playground). If you use a preset, all other parameters become optional, and any included parameters will override the preset's parameters.<br/>
         /// Included only in requests<br/>
         /// Example: my-preset-a58sbd
         /// </param>

--- a/src/libs/Cohere/Generated/Cohere.Models.ClassifyRequest.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.ClassifyRequest.g.cs
@@ -33,7 +33,7 @@ namespace Cohere
         public string? Model { get; set; }
 
         /// <summary>
-        /// The ID of a custom playground preset. You can create presets in the [playground](https://dashboard.cohere.com/playground/classify?model=large). If you use a preset, all other parameters become optional, and any included parameters will override the preset's parameters.<br/>
+        /// The ID of a custom playground preset. You can create presets in the [playground](https://dashboard.cohere.com/playground). If you use a preset, all other parameters become optional, and any included parameters will override the preset's parameters.<br/>
         /// Included only in requests<br/>
         /// Example: my-preset-a58sbd
         /// </summary>

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -849,7 +849,7 @@ paths:
                     - public
                 preset:
                   type: string
-                  description: 'The ID of a custom playground preset. You can create presets in the [playground](https://dashboard.cohere.com/playground/classify?model=large). If you use a preset, all other parameters become optional, and any included parameters will override the preset''s parameters.'
+                  description: 'The ID of a custom playground preset. You can create presets in the [playground](https://dashboard.cohere.com/playground). If you use a preset, all other parameters become optional, and any included parameters will override the preset''s parameters.'
                   writeOnly: true
                   example: my-preset-a58sbd
                   deprecated: true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the description text for the `preset` parameter in the API documentation to reference a more general playground URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->