### PR TITLE
feat:Add raw_prompting boolean parameter to two Cohere request schemas

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.CohereClient.Chat.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.CohereClient.Chat.g.cs
@@ -740,6 +740,11 @@ namespace Cohere
         ///  - AUTO: Cohere Platform Only<br/>
         ///  - AUTO_PRESERVE_ORDER: Azure, AWS Sagemaker/Bedrock, Private Deployments
         /// </param>
+        /// <param name="rawPrompting">
+        /// When enabled, the user's prompt will be sent to the model without<br/>
+        /// any pre-processing.<br/>
+        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+        /// </param>
         /// <param name="responseFormat">
         /// Configuration for forcing the model output to adhere to the specified format. Supported on [Command R 03-2024](https://docs.cohere.com/docs/command-r), [Command R+ 04-2024](https://docs.cohere.com/docs/command-r-plus) and newer models.<br/>
         /// The model can be forced into outputting JSON objects (with up to 5 levels of nesting) by setting `{ "type": "json_object" }`.<br/>
@@ -834,6 +839,7 @@ namespace Cohere
             string? model = default,
             string? preamble = default,
             global::Cohere.ChatRequestPromptTruncation? promptTruncation = default,
+            bool? rawPrompting = default,
             global::Cohere.ResponseFormat? responseFormat = default,
             global::Cohere.ChatRequestSafetyMode? safetyMode = default,
             bool? searchQueriesOnly = default,
@@ -862,6 +868,7 @@ namespace Cohere
                 Preamble = preamble,
                 PresencePenalty = presencePenalty,
                 PromptTruncation = promptTruncation,
+                RawPrompting = rawPrompting,
                 ResponseFormat = responseFormat,
                 SafetyMode = safetyMode,
                 SearchQueriesOnly = searchQueriesOnly,

--- a/src/libs/Cohere/Generated/Cohere.CohereClient.Chatv2.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.CohereClient.Chatv2.g.cs
@@ -667,6 +667,11 @@ namespace Cohere
         /// Defaults to `0.0`, min value of `0.0`, max value of `1.0`.<br/>
         /// Used to reduce repetitiveness of generated tokens. Similar to `frequency_penalty`, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
         /// </param>
+        /// <param name="rawPrompting">
+        /// When enabled, the user's prompt will be sent to the model without<br/>
+        /// any pre-processing.<br/>
+        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+        /// </param>
         /// <param name="reasoningEffort">
         /// The reasoning effort level of the model. This affects the model's performance and the time it takes to generate a response.
         /// </param>
@@ -733,6 +738,7 @@ namespace Cohere
             int? maxTokens = default,
             float? p = default,
             float? presencePenalty = default,
+            bool? rawPrompting = default,
             global::Cohere.ReasoningEffort? reasoningEffort = default,
             global::Cohere.ResponseFormatV2? responseFormat = default,
             global::Cohere.Chatv2RequestSafetyMode? safetyMode = default,
@@ -757,6 +763,7 @@ namespace Cohere
                 Model = model,
                 P = p,
                 PresencePenalty = presencePenalty,
+                RawPrompting = rawPrompting,
                 ReasoningEffort = reasoningEffort,
                 ResponseFormat = responseFormat,
                 SafetyMode = safetyMode,

--- a/src/libs/Cohere/Generated/Cohere.ICohereClient.Chat.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.ICohereClient.Chat.g.cs
@@ -127,6 +127,11 @@ namespace Cohere
         ///  - AUTO: Cohere Platform Only<br/>
         ///  - AUTO_PRESERVE_ORDER: Azure, AWS Sagemaker/Bedrock, Private Deployments
         /// </param>
+        /// <param name="rawPrompting">
+        /// When enabled, the user's prompt will be sent to the model without<br/>
+        /// any pre-processing.<br/>
+        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+        /// </param>
         /// <param name="responseFormat">
         /// Configuration for forcing the model output to adhere to the specified format. Supported on [Command R 03-2024](https://docs.cohere.com/docs/command-r), [Command R+ 04-2024](https://docs.cohere.com/docs/command-r-plus) and newer models.<br/>
         /// The model can be forced into outputting JSON objects (with up to 5 levels of nesting) by setting `{ "type": "json_object" }`.<br/>
@@ -221,6 +226,7 @@ namespace Cohere
             string? model = default,
             string? preamble = default,
             global::Cohere.ChatRequestPromptTruncation? promptTruncation = default,
+            bool? rawPrompting = default,
             global::Cohere.ResponseFormat? responseFormat = default,
             global::Cohere.ChatRequestSafetyMode? safetyMode = default,
             bool? searchQueriesOnly = default,

--- a/src/libs/Cohere/Generated/Cohere.ICohereClient.Chatv2.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.ICohereClient.Chatv2.g.cs
@@ -62,6 +62,11 @@ namespace Cohere
         /// Defaults to `0.0`, min value of `0.0`, max value of `1.0`.<br/>
         /// Used to reduce repetitiveness of generated tokens. Similar to `frequency_penalty`, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
         /// </param>
+        /// <param name="rawPrompting">
+        /// When enabled, the user's prompt will be sent to the model without<br/>
+        /// any pre-processing.<br/>
+        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+        /// </param>
         /// <param name="reasoningEffort">
         /// The reasoning effort level of the model. This affects the model's performance and the time it takes to generate a response.
         /// </param>
@@ -128,6 +133,7 @@ namespace Cohere
             int? maxTokens = default,
             float? p = default,
             float? presencePenalty = default,
+            bool? rawPrompting = default,
             global::Cohere.ReasoningEffort? reasoningEffort = default,
             global::Cohere.ResponseFormatV2? responseFormat = default,
             global::Cohere.Chatv2RequestSafetyMode? safetyMode = default,

--- a/src/libs/Cohere/Generated/Cohere.Models.ChatRequest.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.ChatRequest.g.cs
@@ -160,6 +160,14 @@ namespace Cohere
         public global::Cohere.ChatRequestPromptTruncation? PromptTruncation { get; set; }
 
         /// <summary>
+        /// When enabled, the user's prompt will be sent to the model without<br/>
+        /// any pre-processing.<br/>
+        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("raw_prompting")]
+        public bool? RawPrompting { get; set; }
+
+        /// <summary>
         /// Configuration for forcing the model output to adhere to the specified format. Supported on [Command R 03-2024](https://docs.cohere.com/docs/command-r), [Command R+ 04-2024](https://docs.cohere.com/docs/command-r-plus) and newer models.<br/>
         /// The model can be forced into outputting JSON objects (with up to 5 levels of nesting) by setting `{ "type": "json_object" }`.<br/>
         /// A [JSON Schema](https://json-schema.org/) can optionally be provided, to ensure a specific structure.<br/>
@@ -369,6 +377,11 @@ namespace Cohere
         ///  - AUTO: Cohere Platform Only<br/>
         ///  - AUTO_PRESERVE_ORDER: Azure, AWS Sagemaker/Bedrock, Private Deployments
         /// </param>
+        /// <param name="rawPrompting">
+        /// When enabled, the user's prompt will be sent to the model without<br/>
+        /// any pre-processing.<br/>
+        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+        /// </param>
         /// <param name="responseFormat">
         /// Configuration for forcing the model output to adhere to the specified format. Supported on [Command R 03-2024](https://docs.cohere.com/docs/command-r), [Command R+ 04-2024](https://docs.cohere.com/docs/command-r-plus) and newer models.<br/>
         /// The model can be forced into outputting JSON objects (with up to 5 levels of nesting) by setting `{ "type": "json_object" }`.<br/>
@@ -461,6 +474,7 @@ namespace Cohere
             string? preamble,
             double? presencePenalty,
             global::Cohere.ChatRequestPromptTruncation? promptTruncation,
+            bool? rawPrompting,
             global::Cohere.ResponseFormat? responseFormat,
             global::Cohere.ChatRequestSafetyMode? safetyMode,
             bool? searchQueriesOnly,
@@ -487,6 +501,7 @@ namespace Cohere
             this.Preamble = preamble;
             this.PresencePenalty = presencePenalty;
             this.PromptTruncation = promptTruncation;
+            this.RawPrompting = rawPrompting;
             this.ResponseFormat = responseFormat;
             this.SafetyMode = safetyMode;
             this.SearchQueriesOnly = searchQueriesOnly;

--- a/src/libs/Cohere/Generated/Cohere.Models.Chatv2Request.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.Chatv2Request.g.cs
@@ -81,6 +81,14 @@ namespace Cohere
         public float? PresencePenalty { get; set; }
 
         /// <summary>
+        /// When enabled, the user's prompt will be sent to the model without<br/>
+        /// any pre-processing.<br/>
+        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("raw_prompting")]
+        public bool? RawPrompting { get; set; }
+
+        /// <summary>
         /// The reasoning effort level of the model. This affects the model's performance and the time it takes to generate a response.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("reasoning_effort")]
@@ -213,6 +221,11 @@ namespace Cohere
         /// Defaults to `0.0`, min value of `0.0`, max value of `1.0`.<br/>
         /// Used to reduce repetitiveness of generated tokens. Similar to `frequency_penalty`, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
         /// </param>
+        /// <param name="rawPrompting">
+        /// When enabled, the user's prompt will be sent to the model without<br/>
+        /// any pre-processing.<br/>
+        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
+        /// </param>
         /// <param name="reasoningEffort">
         /// The reasoning effort level of the model. This affects the model's performance and the time it takes to generate a response.
         /// </param>
@@ -279,6 +292,7 @@ namespace Cohere
             int? maxTokens,
             float? p,
             float? presencePenalty,
+            bool? rawPrompting,
             global::Cohere.ReasoningEffort? reasoningEffort,
             global::Cohere.ResponseFormatV2? responseFormat,
             global::Cohere.Chatv2RequestSafetyMode? safetyMode,
@@ -300,6 +314,7 @@ namespace Cohere
             this.MaxTokens = maxTokens;
             this.P = p;
             this.PresencePenalty = presencePenalty;
+            this.RawPrompting = rawPrompting;
             this.ReasoningEffort = reasoningEffort;
             this.ResponseFormat = responseFormat;
             this.SafetyMode = safetyMode;

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -148,6 +148,11 @@ paths:
                   description: "Defaults to `AUTO` when `connectors` are specified and `OFF` in all other cases.\n\nDictates how the prompt will be constructed.\n\nWith `prompt_truncation` set to \"AUTO\", some elements from `chat_history` and `documents` will be dropped in an attempt to construct a prompt that fits within the model's context length limit. During this process the order of the documents and chat history will be changed and ranked by relevance.\n\nWith `prompt_truncation` set to \"AUTO_PRESERVE_ORDER\", some elements from `chat_history` and `documents` will be dropped in an attempt to construct a prompt that fits within the model's context length limit. During this process the order of the documents and chat history will be preserved as they are inputted into the API.\n\nWith `prompt_truncation` set to \"OFF\", no elements will be dropped. If the sum of the inputs exceeds the model's context length limit, a `TooManyTokens` error will be returned.\n\nCompatible Deployments:\n - AUTO: Cohere Platform Only\n - AUTO_PRESERVE_ORDER: Azure, AWS Sagemaker/Bedrock, Private Deployments\n"
                   x-fern-audiences:
                     - public
+                raw_prompting:
+                  type: boolean
+                  description: "When enabled, the user's prompt will be sent to the model without\nany pre-processing.\n\nCompatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments\n"
+                  x-fern-audiences:
+                    - sdk-only
                 response_format:
                   $ref: '#/components/schemas/ResponseFormat'
                 safety_mode:
@@ -7440,6 +7445,11 @@ paths:
                   format: float
                   x-fern-audiences:
                     - public
+                raw_prompting:
+                  type: boolean
+                  description: "When enabled, the user's prompt will be sent to the model without\nany pre-processing.\n\nCompatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments\n"
+                  x-fern-audiences:
+                    - sdk-only
                 reasoning_effort:
                   $ref: '#/components/schemas/ReasoningEffort'
                 response_format:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new option to enable sending prompts directly to the model without pre-processing, available in supported deployment environments. This feature is accessible through SDK integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->