### PR TITLE
feat:Add thinking chat content type, mapping, and optional thinking field

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.Models.AssistantMessageV2ContentVariant2ItemDiscriminatorType.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.AssistantMessageV2ContentVariant2ItemDiscriminatorType.g.cs
@@ -12,6 +12,10 @@ namespace Cohere
         /// 
         /// </summary>
         Text,
+        /// <summary>
+        /// 
+        /// </summary>
+        Thinking,
     }
 
     /// <summary>
@@ -27,6 +31,7 @@ namespace Cohere
             return value switch
             {
                 AssistantMessageV2ContentVariant2ItemDiscriminatorType.Text => "text",
+                AssistantMessageV2ContentVariant2ItemDiscriminatorType.Thinking => "thinking",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -38,6 +43,7 @@ namespace Cohere
             return value switch
             {
                 "text" => AssistantMessageV2ContentVariant2ItemDiscriminatorType.Text,
+                "thinking" => AssistantMessageV2ContentVariant2ItemDiscriminatorType.Thinking,
                 _ => null,
             };
         }

--- a/src/libs/Cohere/Generated/Cohere.Models.ChatContentDeltaEventVariant2DeltaMessageContent.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.ChatContentDeltaEventVariant2DeltaMessageContent.g.cs
@@ -15,6 +15,12 @@ namespace Cohere
         public string? Text { get; set; }
 
         /// <summary>
+        /// 
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("thinking")]
+        public string? Thinking { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -24,13 +30,16 @@ namespace Cohere
         /// Initializes a new instance of the <see cref="ChatContentDeltaEventVariant2DeltaMessageContent" /> class.
         /// </summary>
         /// <param name="text"></param>
+        /// <param name="thinking"></param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public ChatContentDeltaEventVariant2DeltaMessageContent(
-            string? text)
+            string? text,
+            string? thinking)
         {
             this.Text = text;
+            this.Thinking = thinking;
         }
 
         /// <summary>

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -12425,6 +12425,7 @@ components:
                   propertyName: type
                   mapping:
                     text: '#/components/schemas/ChatTextContent'
+                    thinking: '#/components/schemas/ChatThinkingContent'
         role:
           enum:
             - assistant
@@ -12583,6 +12584,8 @@ components:
                       type: object
                       properties:
                         text:
+                          type: string
+                        thinking:
                           type: string
                       x-fern-type-name: ChatContentDeltaEventDeltaMessageContent
                   x-fern-type-name: ChatContentDeltaEventDeltaMessage


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat responses now support an additional “thinking” content type, enabling richer context alongside regular text.
  * Streaming/delta updates may include a new optional “thinking” field in message content, allowing clients to display or handle model reasoning previews if desired.

* **Chores**
  * Public API updated to include the new “thinking” content variant and corresponding field in chat message deltas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->