### PR TITLE
feat:Remove raw_prompting property from Cohere OpenAPI schema

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.CohereClient.Chatv2.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.CohereClient.Chatv2.g.cs
@@ -668,11 +668,6 @@ namespace Cohere
         /// Defaults to `0.0`, min value of `0.0`, max value of `1.0`.<br/>
         /// Used to reduce repetitiveness of generated tokens. Similar to `frequency_penalty`, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
         /// </param>
-        /// <param name="rawPrompting">
-        /// When enabled, the user's prompt will be sent to the model without<br/>
-        /// any pre-processing.<br/>
-        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
-        /// </param>
         /// <param name="responseFormat">
         /// Configuration for forcing the model output to adhere to the specified format. Supported on [Command R](https://docs.cohere.com/v2/docs/command-r), [Command R+](https://docs.cohere.com/v2/docs/command-r-plus) and newer models.<br/>
         /// The model can be forced into outputting JSON objects by setting `{ "type": "json_object" }`.<br/>
@@ -738,7 +733,6 @@ namespace Cohere
             int? maxTokens = default,
             float? p = default,
             float? presencePenalty = default,
-            bool? rawPrompting = default,
             global::Cohere.ResponseFormatV2? responseFormat = default,
             global::Cohere.Chatv2RequestSafetyMode? safetyMode = default,
             int? seed = default,
@@ -763,7 +757,6 @@ namespace Cohere
                 Model = model,
                 P = p,
                 PresencePenalty = presencePenalty,
-                RawPrompting = rawPrompting,
                 ResponseFormat = responseFormat,
                 SafetyMode = safetyMode,
                 Seed = seed,

--- a/src/libs/Cohere/Generated/Cohere.ICohereClient.Chatv2.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.ICohereClient.Chatv2.g.cs
@@ -63,11 +63,6 @@ namespace Cohere
         /// Defaults to `0.0`, min value of `0.0`, max value of `1.0`.<br/>
         /// Used to reduce repetitiveness of generated tokens. Similar to `frequency_penalty`, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
         /// </param>
-        /// <param name="rawPrompting">
-        /// When enabled, the user's prompt will be sent to the model without<br/>
-        /// any pre-processing.<br/>
-        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
-        /// </param>
         /// <param name="responseFormat">
         /// Configuration for forcing the model output to adhere to the specified format. Supported on [Command R](https://docs.cohere.com/v2/docs/command-r), [Command R+](https://docs.cohere.com/v2/docs/command-r-plus) and newer models.<br/>
         /// The model can be forced into outputting JSON objects by setting `{ "type": "json_object" }`.<br/>
@@ -133,7 +128,6 @@ namespace Cohere
             int? maxTokens = default,
             float? p = default,
             float? presencePenalty = default,
-            bool? rawPrompting = default,
             global::Cohere.ResponseFormatV2? responseFormat = default,
             global::Cohere.Chatv2RequestSafetyMode? safetyMode = default,
             int? seed = default,

--- a/src/libs/Cohere/Generated/Cohere.Models.Chatv2Request.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.Chatv2Request.g.cs
@@ -82,14 +82,6 @@ namespace Cohere
         public float? PresencePenalty { get; set; }
 
         /// <summary>
-        /// When enabled, the user's prompt will be sent to the model without<br/>
-        /// any pre-processing.<br/>
-        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("raw_prompting")]
-        public bool? RawPrompting { get; set; }
-
-        /// <summary>
         /// Configuration for forcing the model output to adhere to the specified format. Supported on [Command R](https://docs.cohere.com/v2/docs/command-r), [Command R+](https://docs.cohere.com/v2/docs/command-r-plus) and newer models.<br/>
         /// The model can be forced into outputting JSON objects by setting `{ "type": "json_object" }`.<br/>
         /// A [JSON Schema](https://json-schema.org/) can optionally be provided, to ensure a specific structure.<br/>
@@ -221,11 +213,6 @@ namespace Cohere
         /// Defaults to `0.0`, min value of `0.0`, max value of `1.0`.<br/>
         /// Used to reduce repetitiveness of generated tokens. Similar to `frequency_penalty`, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
         /// </param>
-        /// <param name="rawPrompting">
-        /// When enabled, the user's prompt will be sent to the model without<br/>
-        /// any pre-processing.<br/>
-        /// Compatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments
-        /// </param>
         /// <param name="responseFormat">
         /// Configuration for forcing the model output to adhere to the specified format. Supported on [Command R](https://docs.cohere.com/v2/docs/command-r), [Command R+](https://docs.cohere.com/v2/docs/command-r-plus) and newer models.<br/>
         /// The model can be forced into outputting JSON objects by setting `{ "type": "json_object" }`.<br/>
@@ -291,7 +278,6 @@ namespace Cohere
             int? maxTokens,
             float? p,
             float? presencePenalty,
-            bool? rawPrompting,
             global::Cohere.ResponseFormatV2? responseFormat,
             global::Cohere.Chatv2RequestSafetyMode? safetyMode,
             int? seed,
@@ -313,7 +299,6 @@ namespace Cohere
             this.MaxTokens = maxTokens;
             this.P = p;
             this.PresencePenalty = presencePenalty;
-            this.RawPrompting = rawPrompting;
             this.ResponseFormat = responseFormat;
             this.SafetyMode = safetyMode;
             this.Seed = seed;

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -7439,11 +7439,6 @@ paths:
                   format: float
                   x-fern-audiences:
                     - public
-                raw_prompting:
-                  type: boolean
-                  description: "When enabled, the user's prompt will be sent to the model without\nany pre-processing.\n\nCompatible Deployments: Cohere Platform, Azure, AWS Sagemaker/Bedrock, Private Deployments\n"
-                  x-fern-audiences:
-                    - sdk-only
                 response_format:
                   $ref: '#/components/schemas/ResponseFormatV2'
                 safety_mode:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the raw_prompting option from the Cohere API. Requests including this flag may be rejected or have no effect. Update integrations to remove usage and rely on default prompting behavior.
* **Notes**
  * Other request parameters (e.g., response_format, safety_mode) are unaffected.
  * If you previously used the SDK-only raw_prompting flag, no direct replacement is provided; review your prompting configuration to ensure expected outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->