### PR TITLE
feat:Update openapi.yaml to allow webp and gif for image embeddings

### DIFF
--- a/src/libs/Cohere/Generated/Cohere.CohereClient.Embed.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.CohereClient.Embed.g.cs
@@ -642,7 +642,7 @@ namespace Cohere
         /// </param>
         /// <param name="images">
         /// An array of image data URIs for the model to embed. Maximum number of images per call is `1`.<br/>
-        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.<br/>
+        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.<br/>
         /// Images are only supported with Embed v3.0 and newer models.
         /// </param>
         /// <param name="inputType">

--- a/src/libs/Cohere/Generated/Cohere.CohereClient.Embedv2.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.CohereClient.Embedv2.g.cs
@@ -644,7 +644,7 @@ namespace Cohere
         /// </param>
         /// <param name="images">
         /// An array of image data URIs for the model to embed. Maximum number of images per call is `1`.<br/>
-        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.<br/>
+        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.<br/>
         /// Image embeddings are supported with Embed v3.0 and newer models.
         /// </param>
         /// <param name="inputType">

--- a/src/libs/Cohere/Generated/Cohere.ICohereClient.Embed.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.ICohereClient.Embed.g.cs
@@ -37,7 +37,7 @@ namespace Cohere
         /// </param>
         /// <param name="images">
         /// An array of image data URIs for the model to embed. Maximum number of images per call is `1`.<br/>
-        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.<br/>
+        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.<br/>
         /// Images are only supported with Embed v3.0 and newer models.
         /// </param>
         /// <param name="inputType">

--- a/src/libs/Cohere/Generated/Cohere.ICohereClient.Embedv2.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.ICohereClient.Embedv2.g.cs
@@ -39,7 +39,7 @@ namespace Cohere
         /// </param>
         /// <param name="images">
         /// An array of image data URIs for the model to embed. Maximum number of images per call is `1`.<br/>
-        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.<br/>
+        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.<br/>
         /// Image embeddings are supported with Embed v3.0 and newer models.
         /// </param>
         /// <param name="inputType">

--- a/src/libs/Cohere/Generated/Cohere.Models.EmbedRequest.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.EmbedRequest.g.cs
@@ -22,7 +22,7 @@ namespace Cohere
 
         /// <summary>
         /// An array of image data URIs for the model to embed. Maximum number of images per call is `1`.<br/>
-        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.<br/>
+        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.<br/>
         /// Images are only supported with Embed v3.0 and newer models.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("images")]
@@ -85,7 +85,7 @@ namespace Cohere
         /// </param>
         /// <param name="images">
         /// An array of image data URIs for the model to embed. Maximum number of images per call is `1`.<br/>
-        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.<br/>
+        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.<br/>
         /// Images are only supported with Embed v3.0 and newer models.
         /// </param>
         /// <param name="inputType">

--- a/src/libs/Cohere/Generated/Cohere.Models.Embedv2Request.g.cs
+++ b/src/libs/Cohere/Generated/Cohere.Models.Embedv2Request.g.cs
@@ -24,7 +24,7 @@ namespace Cohere
 
         /// <summary>
         /// An array of image data URIs for the model to embed. Maximum number of images per call is `1`.<br/>
-        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.<br/>
+        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.<br/>
         /// Image embeddings are supported with Embed v3.0 and newer models.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("images")]
@@ -109,7 +109,7 @@ namespace Cohere
         /// </param>
         /// <param name="images">
         /// An array of image data URIs for the model to embed. Maximum number of images per call is `1`.<br/>
-        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.<br/>
+        /// The image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.<br/>
         /// Image embeddings are supported with Embed v3.0 and newer models.
         /// </param>
         /// <param name="inputType">

--- a/src/libs/Cohere/openapi.yaml
+++ b/src/libs/Cohere/openapi.yaml
@@ -2165,7 +2165,7 @@ paths:
                     writeOnly: true
                     x-fern-audiences:
                       - public
-                  description: "An array of image data URIs for the model to embed. Maximum number of images per call is `1`.\n\nThe image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.\n\nImages are only supported with Embed v3.0 and newer models."
+                  description: "An array of image data URIs for the model to embed. Maximum number of images per call is `1`.\n\nThe image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.\n\nImages are only supported with Embed v3.0 and newer models."
                   x-fern-audiences:
                     - public
                 input_type:
@@ -8865,7 +8865,7 @@ paths:
                     writeOnly: true
                     x-fern-audiences:
                       - public
-                  description: "An array of image data URIs for the model to embed. Maximum number of images per call is `1`.\n\nThe image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg` or `image/png` format and has a maximum size of 5MB.\n\nImage embeddings are supported with Embed v3.0 and newer models."
+                  description: "An array of image data URIs for the model to embed. Maximum number of images per call is `1`.\n\nThe image must be a valid [data URI](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data). The image must be in either `image/jpeg`, `image/png`, `image/webp`, or `image/gif` format and has a maximum size of 5MB.\n\nImage embeddings are supported with Embed v3.0 and newer models."
                   x-fern-audiences:
                     - public
                 input_type:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding endpoints now accept WEBP and GIF images, in addition to JPEG and PNG.
  * Backwards-compatible; existing integrations continue to function without changes. One image per call remains supported.

* **Documentation**
  * API documentation updated to list the expanded image formats and clarify allowed data URI types across affected endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->